### PR TITLE
Update groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Documentation
 
-* See [API Javadoc](https://javadoc.io/doc/io.github.gonalez.znpcservers/znpcservers).
+* See [API Javadoc](https://javadoc.io/doc/io.github.znetworkw.znpcservers/znpcservers).
 
 ## Need help?
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```xml
 <dependency>
-   <groupId>io.github.gonalez.znpcservers</groupId>
+   <groupId>io.github.znetworkw.znpcservers</groupId>
    <artifactId>znpcservers</artifactId>
    <version>3.6</version>
 </dependency>


### PR DESCRIPTION
Despite 5bb2ce95cb4ed88fd32bed591cabbf5604be91a4 the groupId is still io.github.znetworkw.znpcservers in Maven central.

Alternatively, I think you could resolve this by releasing the 3.7 version.